### PR TITLE
Fix create_vm index regex

### DIFF
--- a/pymemuc/_manage.py
+++ b/pymemuc/_manage.py
@@ -30,7 +30,7 @@ def create_vm(
     if not success:
         raise PyMemucError(f"Failed to create VM: {output}")
     try:
-        indecies = re.search(r"index:(\w)", output)
+        indecies = re.search(r"index:(\w+)", output)
         return -1 if indecies is None else int(indecies[1])
     except AttributeError:
         return -1


### PR DESCRIPTION
Changed regex because it was only taking single digits, now multiple digits as indexes can be used