### PR TITLE
Fix set_configuration_vm for multi-value configs (closes #192)

### DIFF
--- a/pymemuc/_manage.py
+++ b/pymemuc/_manage.py
@@ -370,10 +370,11 @@ def set_configuration_vm(
     :return: True if the vm configuration was set successfully
     :rtype: Literal[True]
     """
+    config_values = config_value.split()
     if vm_index is not None:
-        status, output = self.memuc_run(["-i", str(vm_index), "setconfigex", config_key, config_value])
+        status, output = self.memuc_run(["-i", str(vm_index), "setconfigex", config_key, *config_values])
     elif vm_name is not None:
-        status, output = self.memuc_run(["-n", vm_name, "setconfigex", config_key, config_value])
+        status, output = self.memuc_run(["-n", vm_name, "setconfigex", config_key, *config_values])
     else:
         msg = "Please specify either a vm index or a vm name"
         raise PyMemucIndexError(msg)


### PR DESCRIPTION
## Summary
- `set_configuration_vm` passed `config_value` as a single argv slot, so multi-token values like `custom_resolution="270 480 120"` reached `memuc.exe` quoted as one parameter and were rejected with `ERROR: invalid config parameter`.
- Split `config_value` on whitespace and unpack into the `memuc_run` args, matching the CLI shape that works in a shell. Single-value configs are unaffected.

Fix proposed by @Broadsword in #192.

## Test plan
- [ ] On a Windows host with MEmu installed, run `memuc.set_configuration_vm(vm_index=0, config_key="custom_resolution", config_value="270 480 120")` and confirm `SUCCESS: setconfig finished.`
- [ ] Verify a single-token config (e.g. `cpus`) still works.
- [ ] Spot-check `geometry` which the reporter suspected has the same issue.