### PR TITLE
fix: split multi-value VM config arguments

### DIFF
--- a/pymemuc/_manage.py
+++ b/pymemuc/_manage.py
@@ -18,15 +18,6 @@ if TYPE_CHECKING:
     from ._types import ConfigKeys, VMInfo
 
 
-_MULTI_ARG_CONFIG_KEYS = {"custom_resolution", "geometry"}
-
-
-def _setconfig_value_args(config_key: ConfigKeys, config_value: str) -> list[str]:
-    if config_key in _MULTI_ARG_CONFIG_KEYS:
-        return config_value.split()
-    return [config_value]
-
-
 @retryable
 def create_vm(self: PyMemuc, vm_version: Literal["76", "96"] = "96") -> int:
     """Create a new VM.
@@ -379,7 +370,8 @@ def set_configuration_vm(
     :return: True if the vm configuration was set successfully
     :rtype: Literal[True]
     """
-    config_value_args = _setconfig_value_args(config_key, config_value)
+    multi_arg_config_keys = {"custom_resolution", "geometry"}
+    config_value_args = config_value.split() if config_key in multi_arg_config_keys else [config_value]
     if vm_index is not None:
         status, output = self.memuc_run(["-i", str(vm_index), "setconfigex", config_key, *config_value_args])
     elif vm_name is not None:

--- a/pymemuc/_manage.py
+++ b/pymemuc/_manage.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
     from ._types import ConfigKeys, VMInfo
 
 
+_MULTI_ARG_CONFIG_KEYS = {"custom_resolution", "geometry"}
+
+
+def _setconfig_value_args(config_key: ConfigKeys, config_value: str) -> list[str]:
+    if config_key in _MULTI_ARG_CONFIG_KEYS:
+        return config_value.split()
+    return [config_value]
+
+
 @retryable
 def create_vm(self: PyMemuc, vm_version: Literal["76", "96"] = "96") -> int:
     """Create a new VM.
@@ -370,10 +379,11 @@ def set_configuration_vm(
     :return: True if the vm configuration was set successfully
     :rtype: Literal[True]
     """
+    config_value_args = _setconfig_value_args(config_key, config_value)
     if vm_index is not None:
-        status, output = self.memuc_run(["-i", str(vm_index), "setconfigex", config_key, config_value])
+        status, output = self.memuc_run(["-i", str(vm_index), "setconfigex", config_key, *config_value_args])
     elif vm_name is not None:
-        status, output = self.memuc_run(["-n", vm_name, "setconfigex", config_key, config_value])
+        status, output = self.memuc_run(["-n", vm_name, "setconfigex", config_key, *config_value_args])
     else:
         msg = "Please specify either a vm index or a vm name"
         raise PyMemucIndexError(msg)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for pymemuc."""

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -1,0 +1,58 @@
+"""Tests for VM management helpers."""
+# ruff: noqa: PT009
+
+from __future__ import annotations
+
+import unittest
+
+from pymemuc import PyMemuc
+from pymemuc._manage import set_configuration_vm
+
+
+class FakeMemuc(PyMemuc):
+    """Minimal PyMemuc test double that records generated memuc commands."""
+
+    def __init__(self) -> None:
+        """Create a fake command runner."""
+        self.commands: list[list[str]] = []
+
+    def memuc_run(self, command: list[str]) -> tuple[int, str]:
+        """Record the command and report a successful memuc invocation."""
+        self.commands.append(command)
+        return 0, "SUCCESS: setconfig finished.\n"
+
+
+class SetConfigurationVmTests(unittest.TestCase):
+    """Tests for set_configuration_vm command generation."""
+
+    def test_custom_resolution_is_passed_as_three_memuc_arguments(self) -> None:
+        """custom_resolution must not be passed as one quoted value."""
+        memuc = FakeMemuc()
+
+        result = set_configuration_vm(
+            memuc,
+            "custom_resolution",
+            "270 480 120",
+            vm_index=0,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            memuc.commands,
+            [["-i", "0", "setconfigex", "custom_resolution", "270", "480", "120"]],
+        )
+
+    def test_single_value_config_preserves_spaces_as_one_argument(self) -> None:
+        """Single-value config keys should continue preserving spaces."""
+        memuc = FakeMemuc()
+
+        set_configuration_vm(memuc, "name", "My VM", vm_name="phone")
+
+        self.assertEqual(
+            memuc.commands,
+            [["-n", "phone", "setconfigex", "name", "My VM"]],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- split `custom_resolution` and `geometry` config values into separate `memuc setconfigex` arguments
- preserve existing single-argument behavior for other config keys, including values with spaces
- add unit coverage for both command-shaping paths

## Test Plan
- [x] `PYTHONPATH=/Users/clawuser/workspace/opensource/2026-06-02/pyclashbot_pymemuc python3 -m unittest discover -s /Users/clawuser/workspace/opensource/2026-06-02/pyclashbot_pymemuc/tests -v`
- [x] `python3 -m ruff check /Users/clawuser/workspace/opensource/2026-06-02/pyclashbot_pymemuc/pymemuc/_manage.py /Users/clawuser/workspace/opensource/2026-06-02/pyclashbot_pymemuc/tests`
- [x] `python3 -m compileall -q /Users/clawuser/workspace/opensource/2026-06-02/pyclashbot_pymemuc/pymemuc`

Fixes #192
